### PR TITLE
Bump org.hibernate:hibernate-core in the maven group across 1 directory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 	<dependency>
 		<groupId>org.hibernate</groupId>
 		<artifactId>hibernate-core</artifactId>
-		<version>4.0.1.Final</version>
+		<version>5.3.20.Final</version>
 	</dependency>
 	<dependency>
     <groupId>javax.servlet</groupId>


### PR DESCRIPTION
Bumps the maven group with 1 update in the / directory: [org.hibernate:hibernate-core](https://github.com/hibernate/hibernate-orm).


Updates `org.hibernate:hibernate-core` from 4.0.1.Final to 5.3.20.Final
- [Release notes](https://github.com/hibernate/hibernate-orm/releases)
- [Changelog](https://github.com/hibernate/hibernate-orm/blob/5.3.20/changelog.txt)
- [Commits](https://github.com/hibernate/hibernate-orm/compare/4.0.1...5.3.20)

---
updated-dependencies:
- dependency-name: org.hibernate:hibernate-core dependency-version: 5.3.20.Final dependency-type: direct:production dependency-group: maven ...